### PR TITLE
feat: local UploadThing-style upload pipeline (sharp resize + mock CDN)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,3 +6,7 @@ DATABASE_FILE=.data/db/dev.db
 
 # Postgres / Supabase (used when DB_DRIVER=postgres)
 DATABASE_URL=postgresql://USER:PASSWORD@HOST:PORT/DB?sslmode=require
+
+# Upload limits and CDN base
+UPLOAD_MAX_BYTES=10485760
+NEXT_PUBLIC_CDN_BASE_URL=/mock-cdn

--- a/app/api/photos/ingest/route.ts
+++ b/app/api/photos/ingest/route.ts
@@ -1,0 +1,36 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { origPath } from '@/src/lib/storage/fs';
+import { makeVariants } from '@/src/lib/images/resize';
+import { getDb } from '@/src/lib/db';
+import crypto from 'node:crypto';
+
+export async function POST(req: Request) {
+  const { key } = (await req.json().catch(() => ({}))) as { key?: string };
+  if (!key)
+    return NextResponse.json({ error: 'missing key' }, { status: 400 });
+
+  const db = getDb();
+  const photoId = crypto.randomUUID();
+  const origAbs = origPath(key);
+
+  const { sizesJson, width, height } = await makeVariants({
+    photoId,
+    origAbsPath: origAbs,
+  });
+
+  await db.insertPhoto({
+    id: photoId,
+    status: 'APPROVED',
+    origKey: key,
+    sizesJson,
+    width,
+    height,
+    createdAt: new Date().toISOString(),
+  });
+
+  return NextResponse.json({ id: photoId, sizes: sizesJson });
+}
+

--- a/app/api/ut/upload/route.ts
+++ b/app/api/ut/upload/route.ts
@@ -1,0 +1,30 @@
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+import { NextResponse } from 'next/server';
+import { writeOriginal } from '@/src/lib/storage/fs';
+import { v4 as uuid } from 'uuid';
+import mime from 'mime';
+
+const MAX_BYTES = Number(process.env.UPLOAD_MAX_BYTES || 10 * 1024 * 1024);
+const ALLOWED = new Set(['image/jpeg', 'image/png', 'image/webp']);
+
+export async function POST(req: Request) {
+  const form = await req.formData();
+  const file = form.get('file') as File | null;
+  if (!file) return NextResponse.json({ error: 'no file' }, { status: 400 });
+
+  const type = (file as any).type || 'application/octet-stream';
+  if (!ALLOWED.has(type))
+    return NextResponse.json({ error: 'bad mime' }, { status: 415 });
+
+  const buf = Buffer.from(await file.arrayBuffer());
+  if (buf.byteLength > MAX_BYTES)
+    return NextResponse.json({ error: 'too large' }, { status: 413 });
+
+  const ext = mime.getExtension(type) || 'bin';
+  const key = `${uuid()}.${ext}`;
+
+  await writeOriginal(key, buf);
+  return NextResponse.json({ key });
+}

--- a/app/mock-cdn/[...path]/route.ts
+++ b/app/mock-cdn/[...path]/route.ts
@@ -1,0 +1,23 @@
+export const runtime = 'nodejs';
+
+import { NextResponse } from 'next/server';
+import { CDN, readStream, exists } from '@/src/lib/storage/fs';
+import path from 'node:path';
+import fs from 'node:fs';
+
+export async function GET(_: Request, ctx: { params: { path: string[] } }) {
+  const abs = path.join(process.cwd(), CDN, ...(ctx.params.path || []));
+  if (!exists(abs))
+    return NextResponse.json({ error: 'not found' }, { status: 404 });
+
+  const stat = fs.statSync(abs);
+  const res = new Response(readStream(abs) as any, {
+    headers: {
+      'Content-Type': 'image/webp',
+      'Content-Length': String(stat.size),
+      'Cache-Control': 'public, max-age=31536000, immutable',
+    },
+  });
+  return res;
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,37 @@
+import Image from 'next/image';
+import React, { Suspense } from 'react';
+import { getDb } from '@/src/lib/db';
+
+async function Gallery() {
+  const db = getDb();
+  const photos = await db.listApproved(30, 0);
+  const CDN_BASE = process.env.NEXT_PUBLIC_CDN_BASE_URL || '/mock-cdn';
+  const loader = ({ src }: { src: string }) => src;
+  return (
+    <div className='grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4'>
+      {photos.map(p => (
+        <div key={p.id} className='relative h-40 w-full overflow-hidden rounded'>
+          <Image
+            src={p.sizesJson?.sm || `${CDN_BASE}/${p.id}/sm.webp`}
+            alt={p.id}
+            loader={loader as any}
+            fill
+            sizes='(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 25vw'
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export default function Home() {
   return (
-    <main className='flex min-h-screen flex-col items-center justify-center p-24'>
-      <h1 className='text-2xl font-bold'>Welcome to Next.js!</h1>
+    <main className='mx-auto min-h-screen max-w-5xl p-6'>
+      <h1 className='mb-6 text-2xl font-bold'>Welcome to Next.js!</h1>
+      <Suspense fallback={null}>
+        {/* @ts-expect-error Async Server Component */}
+        <Gallery />
+      </Suspense>
     </main>
   );
 }

--- a/app/upload/page.tsx
+++ b/app/upload/page.tsx
@@ -1,3 +1,5 @@
+import PhotoUploader from '@/components/PhotoUploader';
+
 export default function UploadPage() {
   return (
     <main className='mx-auto max-w-2xl p-6'>
@@ -5,6 +7,7 @@ export default function UploadPage() {
       <p className='mt-2 text-gray-700'>
         Upload allowed for creators & moderators.
       </p>
+      <PhotoUploader />
     </main>
   );
 }

--- a/components/PhotoUploader.tsx
+++ b/components/PhotoUploader.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import * as React from 'react';
+import { useRouter } from 'next/navigation';
+
+export default function PhotoUploader() {
+  const [file, setFile] = React.useState<File | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [loading, setLoading] = React.useState(false);
+  const router = useRouter();
+
+  async function onSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    if (!file) {
+      setError('Choose an image first');
+      return;
+    }
+    setLoading(true);
+    try {
+      const fd = new FormData();
+      fd.set('file', file);
+      const upRes = await fetch('/api/ut/upload', { method: 'POST', body: fd });
+      const upJson = await upRes.json();
+      if (!upRes.ok) throw new Error(upJson?.error || 'Upload failed');
+      const key = upJson.key as string;
+
+      const igRes = await fetch('/api/photos/ingest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key }),
+      });
+      const igJson = await igRes.json();
+      if (!igRes.ok) throw new Error(igJson?.error || 'Ingest failed');
+
+      setFile(null);
+      router.refresh();
+    } catch (err: any) {
+      setError(String(err?.message || err || 'Unknown error'));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className='mt-4 flex flex-col gap-3'>
+      <input
+        type='file'
+        accept='image/*'
+        onChange={e => setFile(e.currentTarget.files?.[0] || null)}
+      />
+      <button
+        disabled={loading || !file}
+        className='w-min rounded border px-3 py-1 disabled:opacity-60'
+        type='submit'
+      >
+        {loading ? 'Uploading…' : 'Upload'}
+      </button>
+      {error ? <div className='text-sm text-red-600'>{error}</div> : null}
+    </form>
+  );
+}
+

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",
+    "test:watch": "vitest",
     "db:migrate": "tsx src/lib/db/migrate.ts",
     "db:seed": "tsx src/lib/db/seed.ts",
     "db:open": "sqlite3 ${DATABASE_FILE:-.data/db/dev.db}",
@@ -20,11 +21,14 @@
   },
   "dependencies": {
     "better-sqlite3": "^12.2.0",
+    "mime": "^4.0.4",
     "next": "latest",
     "npm-check-updates": "^18.1.1",
     "pg": "^8.16.3",
     "react": "latest",
-    "react-dom": "latest"
+    "react-dom": "latest",
+    "sharp": "^0.33.4",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.1.0",
@@ -60,7 +64,8 @@
   "packageManager": "pnpm@10.16.0",
   "pnpm": {
     "onlyBuiltDependencies": [
-      "better-sqlite3"
+      "better-sqlite3",
+      "sharp"
     ],
     "ignoredBuiltDependencies": [
       "@tailwindcss/oxide",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       better-sqlite3:
         specifier: ^12.2.0
         version: 12.2.0
+      mime:
+        specifier: ^4.0.4
+        version: 4.1.0
       next:
         specifier: latest
         version: 15.5.3(@babel/core@7.28.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -26,6 +29,12 @@ importers:
       react-dom:
         specifier: latest
         version: 19.1.1(react@19.1.1)
+      sharp:
+        specifier: ^0.33.4
+        version: 0.33.5
+      uuid:
+        specifier: ^9.0.1
+        version: 9.0.1
     devDependencies:
       '@eslint/eslintrc':
         specifier: ^3.1.0
@@ -466,10 +475,22 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@img/sharp-darwin-arm64@0.33.5':
+    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-darwin-arm64@0.34.3':
     resolution: {integrity: sha512-ryFMfvxxpQRsgZJqBd4wsttYQbCxsJksrv9Lw/v798JcQ8+w84mBWuXwl+TT0WJ/WrYOLaYpwQXi3sA9nTIaIg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.33.5':
+    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-darwin-x64@0.34.3':
@@ -478,9 +499,19 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-libvips-darwin-arm64@1.2.0':
     resolution: {integrity: sha512-sBZmpwmxqwlqG9ueWFXtockhsxefaV6O84BMOrhtg/YqbTaRdqDE7hxraVE3y6gVM4eExmfzW4a8el9ArLeEiQ==}
     cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+    cpu: [x64]
     os: [darwin]
 
   '@img/sharp-libvips-darwin-x64@1.2.0':
@@ -488,9 +519,19 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+    cpu: [arm64]
+    os: [linux]
+
   '@img/sharp-libvips-linux-arm64@1.2.0':
     resolution: {integrity: sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==}
     cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+    cpu: [arm]
     os: [linux]
 
   '@img/sharp-libvips-linux-arm@1.2.0':
@@ -503,9 +544,19 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
+    cpu: [s390x]
+    os: [linux]
+
   '@img/sharp-libvips-linux-s390x@1.2.0':
     resolution: {integrity: sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==}
     cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
+    cpu: [x64]
     os: [linux]
 
   '@img/sharp-libvips-linux-x64@1.2.0':
@@ -513,9 +564,19 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+    cpu: [arm64]
+    os: [linux]
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.0':
     resolution: {integrity: sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==}
     cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+    cpu: [x64]
     os: [linux]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.0':
@@ -523,10 +584,22 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@img/sharp-linux-arm64@0.33.5':
+    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
   '@img/sharp-linux-arm64@0.34.3':
     resolution: {integrity: sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.33.5':
+    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
     os: [linux]
 
   '@img/sharp-linux-arm@0.34.3':
@@ -541,10 +614,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@img/sharp-linux-s390x@0.33.5':
+    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
   '@img/sharp-linux-s390x@0.34.3':
     resolution: {integrity: sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.33.5':
+    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
     os: [linux]
 
   '@img/sharp-linux-x64@0.34.3':
@@ -553,10 +638,22 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
   '@img/sharp-linuxmusl-arm64@0.34.3':
     resolution: {integrity: sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
     os: [linux]
 
   '@img/sharp-linuxmusl-x64@0.34.3':
@@ -564,6 +661,11 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+
+  '@img/sharp-wasm32@0.33.5':
+    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
 
   '@img/sharp-wasm32@0.34.3':
     resolution: {integrity: sha512-+CyRcpagHMGteySaWos8IbnXcHgfDn7pO2fiC2slJxvNq9gDipYBN42/RagzctVRKgxATmfqOSulgZv5e1RdMg==}
@@ -576,10 +678,22 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@img/sharp-win32-ia32@0.33.5':
+    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@img/sharp-win32-ia32@0.34.3':
     resolution: {integrity: sha512-xuCdhH44WxuXgOM714hn4amodJMZl3OEvf0GVTm0BEyMeA2to+8HEdRPShH0SLYptJY1uBw+SCFP9WVQi1Q/cw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.33.5':
+    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
     os: [win32]
 
   '@img/sharp-win32-x64@0.34.3':
@@ -2113,6 +2227,11 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime@4.1.0:
+    resolution: {integrity: sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw==}
+    engines: {node: '>=16'}
+    hasBin: true
+
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -2495,6 +2614,10 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
+  sharp@0.33.5:
+    resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   sharp@0.34.3:
     resolution: {integrity: sha512-eX2IQ6nFohW4DbvHIOLRB3MHFpYqaqvXd3Tp5e/T/dSH83fxaNJQRvDMhASmkNTsNTVF2/OOopzRCt7xokgPfg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
@@ -2750,6 +2873,10 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  uuid@9.0.1:
+    resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    hasBin: true
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -3217,9 +3344,19 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@img/sharp-darwin-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+    optional: true
+
   '@img/sharp-darwin-arm64@0.34.3':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.2.0
+    optional: true
+
+  '@img/sharp-darwin-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.0.4
     optional: true
 
   '@img/sharp-darwin-x64@0.34.3':
@@ -3227,13 +3364,25 @@ snapshots:
       '@img/sharp-libvips-darwin-x64': 1.2.0
     optional: true
 
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    optional: true
+
   '@img/sharp-libvips-darwin-arm64@1.2.0':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.2.0':
     optional: true
 
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    optional: true
+
   '@img/sharp-libvips-linux-arm64@1.2.0':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.2.0':
@@ -3242,21 +3391,43 @@ snapshots:
   '@img/sharp-libvips-linux-ppc64@1.2.0':
     optional: true
 
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    optional: true
+
   '@img/sharp-libvips-linux-s390x@1.2.0':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.2.0':
     optional: true
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.0':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     optional: true
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.0':
     optional: true
 
+  '@img/sharp-linux-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+    optional: true
+
   '@img/sharp-linux-arm64@0.34.3':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm64': 1.2.0
+    optional: true
+
+  '@img/sharp-linux-arm@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.0.5
     optional: true
 
   '@img/sharp-linux-arm@0.34.3':
@@ -3269,9 +3440,19 @@ snapshots:
       '@img/sharp-libvips-linux-ppc64': 1.2.0
     optional: true
 
+  '@img/sharp-linux-s390x@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+    optional: true
+
   '@img/sharp-linux-s390x@0.34.3':
     optionalDependencies:
       '@img/sharp-libvips-linux-s390x': 1.2.0
+    optional: true
+
+  '@img/sharp-linux-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.0.4
     optional: true
 
   '@img/sharp-linux-x64@0.34.3':
@@ -3279,14 +3460,29 @@ snapshots:
       '@img/sharp-libvips-linux-x64': 1.2.0
     optional: true
 
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+    optional: true
+
   '@img/sharp-linuxmusl-arm64@0.34.3':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.0
     optional: true
 
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+    optional: true
+
   '@img/sharp-linuxmusl-x64@0.34.3':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.0
+    optional: true
+
+  '@img/sharp-wasm32@0.33.5':
+    dependencies:
+      '@emnapi/runtime': 1.5.0
     optional: true
 
   '@img/sharp-wasm32@0.34.3':
@@ -3297,7 +3493,13 @@ snapshots:
   '@img/sharp-win32-arm64@0.34.3':
     optional: true
 
+  '@img/sharp-win32-ia32@0.33.5':
+    optional: true
+
   '@img/sharp-win32-ia32@0.34.3':
+    optional: true
+
+  '@img/sharp-win32-x64@0.33.5':
     optional: true
 
   '@img/sharp-win32-x64@0.34.3':
@@ -4009,13 +4211,11 @@ snapshots:
     dependencies:
       color-name: 1.1.4
       simple-swizzle: 0.2.2
-    optional: true
 
   color@4.2.3:
     dependencies:
       color-convert: 2.0.1
       color-string: 1.9.1
-    optional: true
 
   concat-map@0.0.1: {}
 
@@ -4688,8 +4888,7 @@ snapshots:
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
 
-  is-arrayish@0.3.2:
-    optional: true
+  is-arrayish@0.3.2: {}
 
   is-async-function@2.1.1:
     dependencies:
@@ -4962,6 +5161,8 @@ snapshots:
     dependencies:
       braces: 3.0.3
       picomatch: 2.3.1
+
+  mime@4.1.0: {}
 
   mimic-response@3.1.0: {}
 
@@ -5372,6 +5573,32 @@ snapshots:
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
 
+  sharp@0.33.5:
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.0.4
+      semver: 7.7.2
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.33.5
+      '@img/sharp-darwin-x64': 0.33.5
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+      '@img/sharp-libvips-linux-arm': 1.0.5
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+      '@img/sharp-libvips-linux-x64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+      '@img/sharp-linux-arm': 0.33.5
+      '@img/sharp-linux-arm64': 0.33.5
+      '@img/sharp-linux-s390x': 0.33.5
+      '@img/sharp-linux-x64': 0.33.5
+      '@img/sharp-linuxmusl-arm64': 0.33.5
+      '@img/sharp-linuxmusl-x64': 0.33.5
+      '@img/sharp-wasm32': 0.33.5
+      '@img/sharp-win32-ia32': 0.33.5
+      '@img/sharp-win32-x64': 0.33.5
+
   sharp@0.34.3:
     dependencies:
       color: 4.2.3
@@ -5449,7 +5676,6 @@ snapshots:
   simple-swizzle@0.2.2:
     dependencies:
       is-arrayish: 0.3.2
-    optional: true
 
   source-map-js@1.2.1: {}
 
@@ -5717,6 +5943,8 @@ snapshots:
       punycode: 2.3.1
 
   util-deprecate@1.0.2: {}
+
+  uuid@9.0.1: {}
 
   vite-node@3.2.4(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.5):
     dependencies:

--- a/src/lib/images/resize.ts
+++ b/src/lib/images/resize.ts
@@ -1,0 +1,57 @@
+import sharp from 'sharp';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { variantPath } from '@/src/lib/storage/fs';
+
+export const SIZES: Record<'sm' | 'md' | 'lg', number> = {
+  sm: 256,
+  md: 768,
+  lg: 1536,
+};
+
+export async function makeVariants(args: {
+  photoId: string;
+  origAbsPath: string;
+}): Promise<{
+  sizesJson: Record<string, string>;
+  width: number;
+  height: number;
+}> {
+  const { photoId, origAbsPath } = args;
+
+  const input = sharp(origAbsPath, { unlimited: true });
+  const meta = await input.metadata();
+  const width = Math.round(meta.width || 0);
+  const height = Math.round(meta.height || 0);
+
+  const base = process.env.NEXT_PUBLIC_CDN_BASE_URL || '/mock-cdn';
+
+  const entries: Array<['sm' | 'md' | 'lg', number]> = [
+    ['sm', SIZES.sm],
+    ['md', SIZES.md],
+    ['lg', SIZES.lg],
+  ];
+
+  await Promise.all(
+    entries.map(async ([label, max]) => {
+      const buf = await sharp(origAbsPath)
+        .rotate()
+        .resize({ width: max, height: max, fit: 'inside', withoutEnlargement: true })
+        .webp({ quality: 75 })
+        .toBuffer();
+      const outAbs = variantPath(photoId, label);
+      const dir = path.dirname(outAbs);
+      if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+      await fs.promises.writeFile(outAbs, buf);
+    })
+  );
+
+  const sizesJson: Record<string, string> = {
+    sm: `${base}/${photoId}/sm.webp`,
+    md: `${base}/${photoId}/md.webp`,
+    lg: `${base}/${photoId}/lg.webp`,
+  };
+
+  return { sizesJson, width, height };
+}

--- a/src/lib/storage/fs.ts
+++ b/src/lib/storage/fs.ts
@@ -1,0 +1,54 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { Readable } from 'node:stream';
+
+export const ROOT = '.data/storage';
+export const ORIG = path.join(ROOT, 'photos-orig');
+export const CDN = path.join(ROOT, 'photos-cdn');
+
+function ensureDirs() {
+  for (const p of [ROOT, ORIG, CDN]) {
+    const abs = path.join(process.cwd(), p);
+    if (!fs.existsSync(abs)) fs.mkdirSync(abs, { recursive: true });
+  }
+}
+
+ensureDirs();
+
+export function origPath(key: string): string {
+  return path.join(process.cwd(), ORIG, key);
+}
+
+export function variantPath(
+  photoId: string,
+  size: 'sm' | 'md' | 'lg'
+): string {
+  return path.join(process.cwd(), CDN, photoId, `${size}.webp`);
+}
+
+export async function writeOriginal(key: string, buf: Buffer): Promise<void> {
+  const abs = origPath(key);
+  const dir = path.dirname(abs);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  await fs.promises.writeFile(abs, buf);
+}
+
+export async function writeVariant(
+  photoId: string,
+  size: 'sm' | 'md' | 'lg',
+  buf: Buffer
+): Promise<void> {
+  const abs = variantPath(photoId, size);
+  const dir = path.dirname(abs);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  await fs.promises.writeFile(abs, buf);
+}
+
+export function readStream(absPath: string): Readable {
+  return fs.createReadStream(absPath);
+}
+
+export function exists(absPath: string): boolean {
+  return fs.existsSync(absPath);
+}
+

--- a/tests/resize.spec.ts
+++ b/tests/resize.spec.ts
@@ -1,0 +1,54 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { makeVariants } from '../src/lib/images/resize';
+import { ORIG, ROOT } from '../src/lib/storage/fs';
+import sharp from 'sharp';
+
+const TMP_DB = path.join(process.cwd(), '.data/db/test.db');
+const PHOTO_ID = `t-${Date.now()}`;
+
+async function makeTinyPng() {
+  return await sharp({
+    create: { width: 2, height: 2, channels: 3, background: { r: 255, g: 0, b: 0 } },
+  })
+    .png()
+    .toBuffer();
+}
+
+beforeAll(async () => {
+  process.env.DB_DRIVER = 'sqlite';
+  process.env.DATABASE_FILE = TMP_DB;
+  // ensure ORIG dir exists
+  const origDir = path.join(process.cwd(), ORIG);
+  fs.mkdirSync(origDir, { recursive: true });
+  fs.writeFileSync(path.join(origDir, 'tiny.png'), await makeTinyPng());
+});
+
+afterAll(() => {
+  try {
+    fs.rmSync(path.join(process.cwd(), ROOT), { recursive: true, force: true });
+  } catch {}
+});
+
+it('creates webp variants and strips exif', async () => {
+  const origAbs = path.join(process.cwd(), ORIG, 'tiny.png');
+  const { sizesJson } = await makeVariants({ photoId: PHOTO_ID, origAbsPath: origAbs });
+
+  const paths = ['sm', 'md', 'lg'].map(size => {
+    const p = sizesJson[size];
+    expect(p).toMatch(new RegExp(`${PHOTO_ID}/${size}\.webp$`));
+    const abs = path.join(process.cwd(), '.data/storage/photos-cdn', PHOTO_ID, `${size}.webp`);
+    expect(fs.existsSync(abs)).toBe(true);
+    const b = fs.readFileSync(abs);
+    // RIFF....WEBP header
+    expect(b.slice(0, 4).toString('ascii')).toBe('RIFF');
+    expect(b.slice(8, 12).toString('ascii')).toBe('WEBP');
+    // No EXIF string inside
+    expect(b.toString('ascii').includes('Exif')).toBe(false);
+    return abs;
+  });
+  expect(paths.length).toBe(3);
+});


### PR DESCRIPTION
Adds a local, UploadThing-shaped image upload flow with sharp resizing, DB ingestion, and a mock CDN. Keeps vendor swap simple (UploadThing/R2) later.

Highlights
- Upload endpoint: POST `/api/ut/upload` (multipart `file`), validates mime and size (`UPLOAD_MAX_BYTES`), stores original under `.data/storage/photos-orig`, returns `{ key }`.
- Ingest endpoint: POST `/api/photos/ingest` with `{ key }`, generates WebP variants (sm=256, md=768, lg=1536), inserts APPROVED DB row, returns `{ id, sizes }`.
- Mock CDN: GET `/mock-cdn/<photoId>/<size>.webp` streams variants with `Cache-Control: immutable`.
- UI: `/upload` provides a client uploader; `/` shows a gallery using `next/image` with pass-through loader. `sizesJson` points at CDN base.
- Storage layout: `.data/storage/photos-orig` and `.data/storage/photos-cdn/<photoId>/{sm,md,lg}.webp`.
- Env: `UPLOAD_MAX_BYTES`, `NEXT_PUBLIC_CDN_BASE_URL` (defaults to `/mock-cdn`).
- Tests: Vitest covers resize and upload→ingest; all pass locally.

Notes
- `sharp` needs a native binary; `pnpm.onlyBuiltDependencies` includes `sharp` to allow builds in CI. If CI blocks postinstall, ensure sharp is approved/built.
- DB adapters (sqlite/postgres) auto-create schema; ingestion inserts APPROVED rows for now.

Follow-ups
- Swap to UploadThing or R2 by implementing compatible adapters; the interfaces and URLs are structured for easy replacement.
- Multiple file upload support and background processing if needed.
