### PR TITLE
feat: moderation + original-file inspection (auto-approve on ingest)

### DIFF
--- a/app/api/photos/ingest/route.ts
+++ b/app/api/photos/ingest/route.ts
@@ -1,16 +1,17 @@
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-import { NextResponse } from 'next/server';
-import { origPath } from '@/src/lib/storage/fs';
-import { makeVariants } from '@/src/lib/images/resize';
-import { getDb } from '@/src/lib/db';
 import crypto from 'node:crypto';
+
+import { NextResponse } from 'next/server';
+
+import { getDb } from '@/src/lib/db';
+import { makeVariants } from '@/src/lib/images/resize';
+import { origPath } from '@/src/lib/storage/fs';
 
 export async function POST(req: Request) {
   const { key } = (await req.json().catch(() => ({}))) as { key?: string };
-  if (!key)
-    return NextResponse.json({ error: 'missing key' }, { status: 400 });
+  if (!key) return NextResponse.json({ error: 'missing key' }, { status: 400 });
 
   const db = getDb();
   const photoId = crypto.randomUUID();
@@ -31,6 +32,9 @@ export async function POST(req: Request) {
     createdAt: new Date().toISOString(),
   });
 
-  return NextResponse.json({ id: photoId, sizes: sizesJson });
+  return NextResponse.json({
+    id: photoId,
+    status: 'APPROVED',
+    sizes: sizesJson,
+  });
 }
-

--- a/app/api/ut/upload/route.ts
+++ b/app/api/ut/upload/route.ts
@@ -1,10 +1,11 @@
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
-import { NextResponse } from 'next/server';
-import { writeOriginal } from '@/src/lib/storage/fs';
-import { v4 as uuid } from 'uuid';
 import mime from 'mime';
+import { NextResponse } from 'next/server';
+import { v4 as uuid } from 'uuid';
+
+import { writeOriginal } from '@/src/lib/storage/fs';
 
 const MAX_BYTES = Number(process.env.UPLOAD_MAX_BYTES || 10 * 1024 * 1024);
 const ALLOWED = new Set(['image/jpeg', 'image/png', 'image/webp']);
@@ -14,7 +15,7 @@ export async function POST(req: Request) {
   const file = form.get('file') as File | null;
   if (!file) return NextResponse.json({ error: 'no file' }, { status: 400 });
 
-  const type = (file as any).type || 'application/octet-stream';
+  const type = file.type || 'application/octet-stream';
   if (!ALLOWED.has(type))
     return NextResponse.json({ error: 'bad mime' }, { status: 415 });
 

--- a/app/mock-cdn/[...path]/route.ts
+++ b/app/mock-cdn/[...path]/route.ts
@@ -1,23 +1,42 @@
 export const runtime = 'nodejs';
 
-import { NextResponse } from 'next/server';
-import { CDN, readStream, exists } from '@/src/lib/storage/fs';
-import path from 'node:path';
 import fs from 'node:fs';
+import path from 'node:path';
 
-export async function GET(_: Request, ctx: { params: { path: string[] } }) {
-  const abs = path.join(process.cwd(), CDN, ...(ctx.params.path || []));
+import { NextResponse } from 'next/server';
+
+import { getDb } from '@/src/lib/db';
+import { CDN, exists } from '@/src/lib/storage/fs';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ path: string | string[] }> }
+) {
+  const resolvedParams = await params;
+  const raw = resolvedParams?.path;
+  const parts: string[] = raw ? (Array.isArray(raw) ? raw : [raw]) : [];
+  const abs = path.join(process.cwd(), CDN, ...parts);
   if (!exists(abs))
     return NextResponse.json({ error: 'not found' }, { status: 404 });
 
+  // Enforce status: only APPROVED are publicly served
+  if (parts.length >= 2) {
+    const photoId = parts[0];
+    const db = getDb();
+    const photo = await db.getPhoto(photoId);
+    if (!photo || photo.status !== 'APPROVED') {
+      return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+    }
+  }
+
   const stat = fs.statSync(abs);
-  const res = new Response(readStream(abs) as any, {
+  const body = await fs.promises.readFile(abs);
+  const res = new Response(new Uint8Array(body), {
     headers: {
       'Content-Type': 'image/webp',
       'Content-Length': String(stat.size),
-      'Cache-Control': 'public, max-age=31536000, immutable',
+      'Cache-Control': 'public, max-age=60, must-revalidate',
     },
   });
   return res;
 }
-

--- a/app/mod/original/[id]/route.ts
+++ b/app/mod/original/[id]/route.ts
@@ -1,0 +1,48 @@
+export const runtime = 'nodejs';
+
+import fs from 'node:fs';
+
+import { NextResponse } from 'next/server';
+
+import { getDb } from '@/src/lib/db';
+import { getRoleFromCookies } from '@/src/lib/role-cookie';
+import { origPath, exists } from '@/src/lib/storage/fs';
+
+export async function GET(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  const role = await getRoleFromCookies();
+  if (role !== 'moderator')
+    return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+
+  const db = getDb();
+  const resolvedParams = await params;
+  const id = resolvedParams.id;
+  const photo = await db.getPhoto(id);
+  if (!photo) return NextResponse.json({ error: 'not found' }, { status: 404 });
+
+  const abs = origPath(photo.origKey);
+  if (!exists(abs))
+    return NextResponse.json({ error: 'file missing' }, { status: 404 });
+
+  const stat = fs.statSync(abs);
+  const key = photo.origKey.toLowerCase();
+  const ct =
+    key.endsWith('.jpg') || key.endsWith('.jpeg')
+      ? 'image/jpeg'
+      : key.endsWith('.png')
+        ? 'image/png'
+        : key.endsWith('.webp')
+          ? 'image/webp'
+          : 'application/octet-stream';
+
+  const body = await fs.promises.readFile(abs);
+  return new Response(new Uint8Array(body), {
+    headers: {
+      'Content-Type': ct,
+      'Content-Length': String(stat.size),
+      'Cache-Control': 'private, no-store',
+    },
+  });
+}

--- a/app/moderate/actions.ts
+++ b/app/moderate/actions.ts
@@ -1,0 +1,27 @@
+'use server';
+
+import { revalidatePath } from 'next/cache';
+
+import { getDb } from '@/src/lib/db';
+
+export async function rejectPhoto(id: string, reason?: string) {
+  const db = getDb();
+  await db.setStatus(id, 'REJECTED', { rejectionReason: reason });
+  try {
+    revalidatePath('/');
+    revalidatePath('/moderate');
+  } catch {
+    // ignore revalidate errors in tests
+  }
+}
+
+export async function restorePhoto(id: string) {
+  const db = getDb();
+  await db.setStatus(id, 'APPROVED', { rejectionReason: null });
+  try {
+    revalidatePath('/');
+    revalidatePath('/moderate');
+  } catch {
+    // ignore revalidate errors in tests
+  }
+}

--- a/app/moderate/page.tsx
+++ b/app/moderate/page.tsx
@@ -1,8 +1,81 @@
-export default function ModeratePage() {
+import Link from 'next/link';
+
+import { getDb } from '@/src/lib/db';
+
+import { rejectPhoto, restorePhoto } from './actions';
+
+export default async function ModeratePage() {
+  const db = getDb();
+  const items = await db.listRecent(200, 0);
+
+  async function rejectAction(formData: FormData) {
+    'use server';
+    const id = String(formData.get('id'));
+    const reason = formData.get('reason')
+      ? String(formData.get('reason'))
+      : undefined;
+    await rejectPhoto(id, reason);
+  }
+
+  async function restoreAction(formData: FormData) {
+    'use server';
+    const id = String(formData.get('id'));
+    await restorePhoto(id);
+  }
+
   return (
-    <main className='mx-auto max-w-2xl p-6'>
-      <h1 className='text-xl font-semibold'>Moderation</h1>
-      <p className='mt-2 text-gray-700'>Moderator area.</p>
+    <main className='mx-auto max-w-5xl p-6'>
+      <h1 className='mb-4 text-2xl font-semibold'>Moderation</h1>
+      <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3'>
+        {items.map(p => (
+          <div key={p.id} className='rounded border p-3'>
+            <div className='mb-2 flex items-center justify-between text-xs text-gray-600'>
+              <span className='rounded bg-gray-100 px-2 py-0.5 font-mono'>
+                {p.status}
+              </span>
+              <Link
+                className='underline'
+                href={`/mod/original/${p.id}`}
+                target='_blank'
+              >
+                Inspect original
+              </Link>
+            </div>
+            <div className='mb-2 overflow-hidden rounded'>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={p.sizesJson?.md || p.sizesJson?.sm}
+                alt={p.id}
+                className='h-48 w-full object-cover'
+              />
+            </div>
+            <form action={rejectAction} className='flex items-center gap-2'>
+              <input type='hidden' name='id' value={p.id} />
+              <input
+                type='text'
+                name='reason'
+                placeholder='Rejection reason (optional)'
+                className='flex-1 rounded border px-2 py-1 text-sm'
+                defaultValue={p.rejectionReason || ''}
+              />
+              <button
+                className='rounded border bg-red-50 px-2 py-1 text-sm'
+                disabled={p.status === 'REJECTED'}
+              >
+                Reject
+              </button>
+            </form>
+            {p.status === 'REJECTED' && (
+              <form action={restoreAction} className='mt-2'>
+                <input type='hidden' name='id' value={p.id} />
+                <button className='rounded border bg-green-50 px-2 py-1 text-sm'>
+                  Restore
+                </button>
+              </form>
+            )}
+          </div>
+        ))}
+      </div>
     </main>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,6 @@
 import Image from 'next/image';
 import React, { Suspense } from 'react';
+
 import { getDb } from '@/src/lib/db';
 
 async function Gallery() {
@@ -10,11 +11,14 @@ async function Gallery() {
   return (
     <div className='grid grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-4'>
       {photos.map(p => (
-        <div key={p.id} className='relative h-40 w-full overflow-hidden rounded'>
+        <div
+          key={p.id}
+          className='relative h-40 w-full overflow-hidden rounded'
+        >
           <Image
             src={p.sizesJson?.sm || `${CDN_BASE}/${p.id}/sm.webp`}
             alt={p.id}
-            loader={loader as any}
+            loader={loader}
             fill
             sizes='(max-width: 768px) 50vw, (max-width: 1200px) 33vw, 25vw'
           />
@@ -29,7 +33,6 @@ export default function Home() {
     <main className='mx-auto min-h-screen max-w-5xl p-6'>
       <h1 className='mb-6 text-2xl font-bold'>Welcome to Next.js!</h1>
       <Suspense fallback={null}>
-        {/* @ts-expect-error Async Server Component */}
         <Gallery />
       </Suspense>
     </main>

--- a/components/PhotoUploader.tsx
+++ b/components/PhotoUploader.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import * as React from 'react';
 import { useRouter } from 'next/navigation';
+import * as React from 'react';
 
 export default function PhotoUploader() {
   const [file, setFile] = React.useState<File | null>(null);
@@ -35,8 +35,9 @@ export default function PhotoUploader() {
 
       setFile(null);
       router.refresh();
-    } catch (err: any) {
-      setError(String(err?.message || err || 'Unknown error'));
+    } catch (err: unknown) {
+      const m = err instanceof Error ? err.message : String(err);
+      setError(m || 'Unknown error');
     } finally {
       setLoading(false);
     }
@@ -60,4 +61,3 @@ export default function PhotoUploader() {
     </form>
   );
 }
-

--- a/docs/dev-instructions.md
+++ b/docs/dev-instructions.md
@@ -1,0 +1,55 @@
+# Dev Instructions — Upload + Moderation
+
+This document summarizes the local upload pipeline and Step 4 moderation additions.
+
+## What’s Included
+
+- Local UploadThing-shaped flow (no vendor): originals saved to `.data/storage/photos-orig`.
+- Sharp-resized WebP variants: `.data/storage/photos-cdn/<photoId>/{sm,md,lg}.webp`.
+- Auto-approve on ingest: newly ingested photos have `status = APPROVED`.
+- Moderator features:
+  - Reject/restore photos via `/moderate` (server actions).
+  - Inspect/download original (unaltered, EXIF intact) via `/mod/original/:id` (moderators only).
+  - Public CDN `/mock-cdn/*` serves only `APPROVED` photos; stops ~within 60s after rejection.
+
+## Endpoints
+
+- POST `/api/ut/upload` (multipart): saves original, returns `{ key }`.
+- POST `/api/photos/ingest` (JSON `{ key }`): creates DB row, generates variants, returns `{ id, status: 'APPROVED' }`.
+- GET `/mock-cdn/<photoId>/<size>.webp`: serves variants with `Cache-Control: public, max-age=60, must-revalidate`.
+- GET `/mod/original/<id>`: moderator-only original file, `Cache-Control: private, no-store`.
+
+## DB Model & Adapters
+
+- Photo fields: `id, status, origKey, sizesJson, width, height, createdAt, updatedAt?, rejectionReason?`.
+- SQLite (`src/lib/db/sqlite.ts`): idempotent ALTERs add `updatedAt`, `rejectionReason`.
+- Postgres (`src/lib/db/postgres.ts`): same columns ensured; uses JSONB for `sizesJson`.
+- Port changes (`src/lib/db/port.ts`):
+  - `setStatus(id, status, extras?: { rejectionReason?: string | null })` updates `status`, optional reason, and `updatedAt`.
+  - `listRecent(limit?, offset?)` for moderation view.
+
+## UI
+
+- `/upload`: client `PhotoUploader` posts file → ingest → refresh; appears on `/` gallery.
+- `/`: gallery shows approved photos via Next Image; URLs come from `sizesJson`.
+- `/moderate`: lists recent photos with status badge, Reject/Restore, and “Inspect original” link.
+
+## Env
+
+- `UPLOAD_MAX_BYTES=10485760`
+- `NEXT_PUBLIC_CDN_BASE_URL=/mock-cdn`
+
+## Scripts
+
+- `pnpm dev` — run app locally
+- `pnpm test` — runs resize, upload/ingest, and moderation flow tests
+- `pnpm lint` — eslint (import-order, types) must pass
+- `pnpm build` — Next.js production build
+
+## Notes
+
+- Sharp requires a native binary; CI must allow building `sharp` (see package.json pnpm.onlyBuiltDependencies).
+- Route handlers use typed param objects compatible with Next 15:
+  - Catch-all: `{ params: { path: string | string[] } }`
+  - Segment param: `{ params: { id: string } }`
+

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/pg": "^8.15.5",
     "@types/react": "latest",
     "@types/react-dom": "latest",
+    "@types/uuid": "^10.0.0",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "@vitejs/plugin-react": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,6 +63,9 @@ importers:
       '@types/react-dom':
         specifier: latest
         version: 19.1.9(@types/react@19.1.13)
+      '@types/uuid':
+        specifier: ^10.0.0
+        version: 10.0.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.0.0
         version: 8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)
@@ -1050,6 +1053,9 @@ packages:
 
   '@types/react@19.1.13':
     resolution: {integrity: sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==}
+
+  '@types/uuid@10.0.0':
+    resolution: {integrity: sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==}
 
   '@typescript-eslint/eslint-plugin@8.43.0':
     resolution: {integrity: sha512-8tg+gt7ENL7KewsKMKDHXR1vm8tt9eMxjJBYINf6swonlWgkYn5NwyIgXpbbDxTNU5DgpDFfj95prcTq2clIQQ==}
@@ -3785,6 +3791,8 @@ snapshots:
   '@types/react@19.1.13':
     dependencies:
       csstype: 3.1.3
+
+  '@types/uuid@10.0.0': {}
 
   '@typescript-eslint/eslint-plugin@8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.35.0(jiti@2.5.1))(typescript@5.9.2)':
     dependencies:

--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -23,7 +23,8 @@ function getDb(): DbPort {
     insertPhoto: async p => (await load()).insertPhoto(p),
     updatePhotoSizes: async (id, sizesJson, width, height) =>
       (await load()).updatePhotoSizes(id, sizesJson, width, height),
-    setStatus: async (id, status) => (await load()).setStatus(id, status),
+    setStatus: async (id, status, extras) =>
+      (await load()).setStatus(id, status, extras),
     deletePhoto: async id => (await load()).deletePhoto(id),
     getPhoto: async id => (await load()).getPhoto(id),
     listApproved: async (limit, offset) =>
@@ -32,5 +33,7 @@ function getDb(): DbPort {
       (await load()).listPending(limit, offset),
     countApproved: async () => (await load()).countApproved(),
     countPending: async () => (await load()).countPending(),
+    listRecent: async (limit, offset) =>
+      (await load()).listRecent(limit, offset),
   } satisfies DbPort;
 }

--- a/src/lib/db/port.ts
+++ b/src/lib/db/port.ts
@@ -8,11 +8,16 @@ export type DbPort = {
     width?: number | null,
     height?: number | null
   ): void | Promise<void>;
-  setStatus(id: string, status: PhotoStatus): void | Promise<void>;
+  setStatus(
+    id: string,
+    status: PhotoStatus,
+    extras?: { rejectionReason?: string | null }
+  ): void | Promise<void>;
   deletePhoto(id: string): void | Promise<void>;
   getPhoto(id: string): Photo | undefined | Promise<Photo | undefined>;
   listApproved(limit?: number, offset?: number): Photo[] | Promise<Photo[]>;
   listPending(limit?: number, offset?: number): Photo[] | Promise<Photo[]>;
   countApproved(): number | Promise<number>;
   countPending(): number | Promise<number>;
+  listRecent(limit?: number, offset?: number): Photo[] | Promise<Photo[]>;
 };

--- a/src/lib/db/types.ts
+++ b/src/lib/db/types.ts
@@ -8,4 +8,6 @@ export type Photo = {
   width?: number | null;
   height?: number | null;
   createdAt: string; // ISO
+  updatedAt?: string | null; // ISO
+  rejectionReason?: string | null;
 };

--- a/src/lib/images/resize.ts
+++ b/src/lib/images/resize.ts
@@ -1,6 +1,7 @@
-import sharp from 'sharp';
 import fs from 'node:fs';
 import path from 'node:path';
+
+import sharp from 'sharp';
 
 import { variantPath } from '@/src/lib/storage/fs';
 
@@ -37,7 +38,12 @@ export async function makeVariants(args: {
     entries.map(async ([label, max]) => {
       const buf = await sharp(origAbsPath)
         .rotate()
-        .resize({ width: max, height: max, fit: 'inside', withoutEnlargement: true })
+        .resize({
+          width: max,
+          height: max,
+          fit: 'inside',
+          withoutEnlargement: true,
+        })
         .webp({ quality: 75 })
         .toBuffer();
       const outAbs = variantPath(photoId, label);

--- a/src/lib/storage/fs.ts
+++ b/src/lib/storage/fs.ts
@@ -19,10 +19,7 @@ export function origPath(key: string): string {
   return path.join(process.cwd(), ORIG, key);
 }
 
-export function variantPath(
-  photoId: string,
-  size: 'sm' | 'md' | 'lg'
-): string {
+export function variantPath(photoId: string, size: 'sm' | 'md' | 'lg'): string {
   return path.join(process.cwd(), CDN, photoId, `${size}.webp`);
 }
 
@@ -51,4 +48,3 @@ export function readStream(absPath: string): Readable {
 export function exists(absPath: string): boolean {
   return fs.existsSync(absPath);
 }
-

--- a/tests/moderation.flow.spec.ts
+++ b/tests/moderation.flow.spec.ts
@@ -1,0 +1,107 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { ORIG, ROOT } from '../src/lib/storage/fs';
+
+const TMP_DB = path.join(process.cwd(), '.data/db/test.db');
+
+async function tinyPngBuffer() {
+  const sharp = (await import('sharp')).default;
+  return await sharp({
+    create: {
+      width: 3,
+      height: 3,
+      channels: 3,
+      background: { r: 10, g: 20, b: 30 },
+    },
+  })
+    .png()
+    .toBuffer();
+}
+
+beforeAll(() => {
+  process.env.DB_DRIVER = 'sqlite';
+  process.env.DATABASE_FILE = TMP_DB;
+});
+
+afterAll(() => {
+  try {
+    fs.rmSync(path.join(process.cwd(), ROOT), { recursive: true, force: true });
+  } catch {}
+});
+
+describe('moderation flow', () => {
+  it('approves on ingest, can reject/restore, original accessible to moderator', async () => {
+    const { POST: upload } = await import('../app/api/ut/upload/route');
+    const { POST: ingest } = await import('../app/api/photos/ingest/route');
+    const fd = new FormData();
+    fd.set(
+      'file',
+      new Blob([await tinyPngBuffer()], { type: 'image/png' }),
+      'tiny.png'
+    );
+    const upRes = await upload(
+      new Request('http://local/api/ut/upload', { method: 'POST', body: fd })
+    );
+    const upJson = await upRes.json();
+    expect(upJson.key).toBeTruthy();
+    const origAbs = path.join(process.cwd(), ORIG, upJson.key);
+    const origSize = fs.statSync(origAbs).size;
+
+    const igRes = await ingest(
+      new Request('http://local/api/photos/ingest', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: upJson.key }),
+      })
+    );
+    const igJson = await igRes.json();
+    expect(igJson.status).toBe('APPROVED');
+    const id = igJson.id as string;
+
+    // CDN serves when approved
+    const { GET: cdnGet } = await import('../app/mock-cdn/[...path]/route');
+    const okRes = await cdnGet(new Request('http://local/mock-cdn'), {
+      params: { path: [id, 'sm.webp'] },
+    } as any);
+    expect(okRes.status).toBe(200);
+    await okRes.arrayBuffer();
+
+    // Reject via server action
+    const { rejectPhoto, restorePhoto } = await import(
+      '../app/moderate/actions'
+    );
+    await rejectPhoto(id, 'not suitable');
+
+    // CDN should block now
+    const forbRes = await cdnGet(new Request('http://local/mock-cdn'), {
+      params: { path: [id, 'sm.webp'] },
+    } as any);
+    expect(forbRes.status).toBe(403);
+    await forbRes.arrayBuffer().catch(() => {});
+
+    // Mock role cookie to allow original access
+    vi.doMock('../src/lib/role-cookie', () => ({
+      getRoleFromCookies: async () => 'moderator',
+      setRoleCookie: async () => {},
+      COOKIE_NAME: 'role',
+    }));
+    const { GET: origGet } = await import('../app/mod/original/[id]/route');
+    const oRes = await origGet(new Request('http://local/mod/original'), {
+      params: { id },
+    } as any);
+    expect(oRes.status).toBe(200);
+    expect(oRes.headers.get('Content-Length')).toBe(String(origSize));
+    await oRes.arrayBuffer();
+
+    // Restore approval
+    await restorePhoto(id);
+    const okRes2 = await cdnGet(new Request('http://local/mock-cdn'), {
+      params: { path: [id, 'sm.webp'] },
+    } as any);
+    expect(okRes2.status).toBe(200);
+    await okRes2.arrayBuffer();
+  });
+});

--- a/tests/resize.spec.ts
+++ b/tests/resize.spec.ts
@@ -12,7 +12,12 @@ const PHOTO_ID = `t-${Date.now()}`;
 
 async function makeTinyPng() {
   return await sharp({
-    create: { width: 2, height: 2, channels: 3, background: { r: 255, g: 0, b: 0 } },
+    create: {
+      width: 2,
+      height: 2,
+      channels: 3,
+      background: { r: 255, g: 0, b: 0 },
+    },
   })
     .png()
     .toBuffer();
@@ -35,12 +40,20 @@ afterAll(() => {
 
 it('creates webp variants and strips exif', async () => {
   const origAbs = path.join(process.cwd(), ORIG, 'tiny.png');
-  const { sizesJson } = await makeVariants({ photoId: PHOTO_ID, origAbsPath: origAbs });
+  const { sizesJson } = await makeVariants({
+    photoId: PHOTO_ID,
+    origAbsPath: origAbs,
+  });
 
   const paths = ['sm', 'md', 'lg'].map(size => {
     const p = sizesJson[size];
-    expect(p).toMatch(new RegExp(`${PHOTO_ID}/${size}\.webp$`));
-    const abs = path.join(process.cwd(), '.data/storage/photos-cdn', PHOTO_ID, `${size}.webp`);
+    expect(p).toMatch(new RegExp(`${PHOTO_ID}/${size}\\.webp$`));
+    const abs = path.join(
+      process.cwd(),
+      '.data/storage/photos-cdn',
+      PHOTO_ID,
+      `${size}.webp`
+    );
     expect(fs.existsSync(abs)).toBe(true);
     const b = fs.readFileSync(abs);
     // RIFF....WEBP header

--- a/tests/upload_ingest.spec.ts
+++ b/tests/upload_ingest.spec.ts
@@ -21,7 +21,12 @@ afterAll(() => {
 async function buildTinyPngBlob(): Promise<Blob> {
   const sharp = (await import('sharp')).default;
   const buf = await sharp({
-    create: { width: 2, height: 2, channels: 3, background: { r: 0, g: 255, b: 0 } },
+    create: {
+      width: 2,
+      height: 2,
+      channels: 3,
+      background: { r: 0, g: 255, b: 0 },
+    },
   })
     .png()
     .toBuffer();
@@ -33,7 +38,9 @@ it('upload then ingest creates files and DB row', async () => {
   const { POST: ingest } = await import('../app/api/photos/ingest/route');
   const fd = new FormData();
   fd.set('file', await buildTinyPngBlob(), 'tiny.png');
-  const upRes = await upload(new Request('http://localhost/api/ut/upload', { method: 'POST', body: fd }));
+  const upRes = await upload(
+    new Request('http://localhost/api/ut/upload', { method: 'POST', body: fd })
+  );
   const upJson = await upRes.json();
   expect(upJson.key).toBeTruthy();
   const origAbs = path.join(process.cwd(), ORIG, upJson.key);


### PR DESCRIPTION
Step 4: Adds auto-approve on ingest, moderator reject/restore, secure original-file inspection, and CDN enforcement.

Highlights
- Auto-approve on ingest: `/api/photos/ingest` inserts with `status=APPROVED` and generates WebP variants (sm=256, md=768, lg=1536).
- Moderator actions: server actions in `/moderate` allow Reject (with optional reason) and Restore.
- Original route: `/mod/original/:id` (moderator-only) streams the unaltered original with `Cache-Control: private, no-store`.
- CDN approval enforcement: `/mock-cdn/*` now serves only `APPROVED` photos; returns 403 for others. Short cache: `public, max-age=60, must-revalidate`.

DB & Port
- Schema adds `updatedAt` and `rejectionReason` (idempotent for SQLite; IF NOT EXISTS for Postgres).
- `setStatus(id, status, extras?)` updates status, optional reason, and `updatedAt`.
- `listRecent(limit, offset)` powers the moderation page.

Docs & Tests
- docs/DEV-NOTES.md updated with moderation/originals and CDN enforcement details.
- New test: `tests/moderation.flow.spec.ts` validates approval → reject → original → restore flow.

Notes
- Route handler param typing aligned with Next 15 (`{ params: { path: string | string[] } }` / `{ params: { id: string } }`).
- No env changes. Public gallery uses approved photos only.
