### PR TITLE
Add SQLite schema bootstrap for users and photo owner

### DIFF
--- a/docs/DEV-NOTES.md
+++ b/docs/DEV-NOTES.md
@@ -26,6 +26,20 @@ Purpose: short, practical notes kept in sync with code. Optimized for LLMs and h
 
 ---
 
+## Users & Roles (local-first plan)
+
+- Roles we actually use: **user**, **moderator**.
+- All signed-in users are "users" (view approved, upload, delete their own). Moderators can approve/reject any photo (and later delete users).
+- We **do not** use a "pending" stage now. New uploads default to **APPROVED**; moderators may later **REJECT**.
+- Step 1 (SQLite only):
+  - Adds `User` table and seeds two dev accounts: `sqlite-user` (role: user) and `sqlite-moderator` (role: moderator).
+  - Adds `Photo.ownerId` (nullable initially), plus helpful indexes.
+  - Adds a SQLite trigger to default `Photo.status` to `APPROVED` if not provided.
+- Step 2 will replace the role cookie with a dev session cookie and `/dev/login` to pick `sqlite-user` or `sqlite-moderator`.
+- Step 3 will set `ownerId` on upload and add "My photos" + creator public pages.
+
+---
+
 ## Storage Port & Drivers (Step 5)
 
 - Port: `src/ports/storage.ts` → `getStorage()`

--- a/src/lib/db/ensure-sqlite.ts
+++ b/src/lib/db/ensure-sqlite.ts
@@ -1,0 +1,77 @@
+// Ensures SQLite has a Users table and Photo.ownerId, plus helpful indexes & defaults.
+// Safe to run multiple times. Only runs when DB_DRIVER=sqlite.
+import Database from 'better-sqlite3';
+
+function columnExists(db: Database.Database, table: string, col: string) {
+  const rows = db.prepare(`PRAGMA table_info(${table})`).all() as Array<{
+    name?: string;
+  }>;
+  return rows.some(row => row.name === col);
+}
+
+export function ensureSqliteSchema(db: Database.Database) {
+  // Users table (dev/local auth users now; later Supabase-auth users will map to this too)
+  db.prepare(
+    `
+    CREATE TABLE IF NOT EXISTS user (
+      id TEXT PRIMARY KEY,
+      email TEXT,
+      displayname TEXT NOT NULL,
+      role TEXT NOT NULL CHECK (role IN ('user','moderator')),
+      createdat TEXT NOT NULL DEFAULT (datetime('now')),
+      deletedat TEXT
+    )
+  `
+  ).run();
+
+  // Add photo.ownerid if missing (nullable until we switch uploads in Step 3)
+  if (!columnExists(db, 'photo', 'ownerid')) {
+    db.prepare(
+      `
+      ALTER TABLE photo ADD COLUMN ownerid TEXT NULL REFERENCES user(id) ON DELETE SET NULL
+    `
+    ).run();
+  }
+
+  // Helpful indexes
+  db.prepare(
+    `
+    CREATE INDEX IF NOT EXISTS idx_photo_owner_created ON photo (ownerid, createdat DESC)
+  `
+  ).run();
+  db.prepare(
+    `
+    CREATE INDEX IF NOT EXISTS idx_photo_status_created ON photo (status, createdat DESC)
+  `
+  ).run();
+
+  // If the Photo table exists without a default for status, enforce "APPROVED" at insert via trigger.
+  // (We do NOT introduce a "PENDING" stage now; keeping that as a capability only.)
+  db.prepare(
+    `
+    CREATE TRIGGER IF NOT EXISTS trg_photo_status_default
+    AFTER INSERT ON photo
+    WHEN NEW.status IS NULL
+    BEGIN
+      UPDATE photo SET status = 'APPROVED' WHERE id = NEW.id;
+    END
+  `
+  ).run();
+
+  // Seed two dev users for local work. Ids are stable and human-readable.
+  db.prepare(
+    `
+    INSERT OR IGNORE INTO user (id, email, displayname, role)
+    VALUES
+      ('sqlite-user', NULL, 'SQLite User', 'user'),
+      ('sqlite-moderator', NULL, 'SQLite Moderator', 'moderator')
+  `
+  ).run();
+}
+
+export function ensureSqlite(dbFile: string) {
+  const db = new Database(dbFile);
+  db.pragma('journal_mode = WAL');
+  ensureSqliteSchema(db);
+  return db;
+}

--- a/src/lib/db/sqlite.ts
+++ b/src/lib/db/sqlite.ts
@@ -3,6 +3,8 @@ import path from 'node:path';
 
 import Database from 'better-sqlite3';
 
+import { ensureSqliteSchema } from '@/src/lib/db/ensure-sqlite';
+
 import type { DbPort } from './port';
 import type { Photo, PhotoStatus } from './types';
 
@@ -65,6 +67,11 @@ function getConn() {
   db.exec(`
     CREATE INDEX IF NOT EXISTS idx_photo_deleted ON photo(deletedat);
   `);
+  try {
+    ensureSqliteSchema(db);
+  } catch (e) {
+    console.error('[sqlite ensure schema] error:', e);
+  }
   return db;
 }
 

--- a/src/lib/users.ts
+++ b/src/lib/users.ts
@@ -1,0 +1,21 @@
+// Minimal user types for Step 1 (used later in Step 2 auth wiring)
+export type UserRole = 'user' | 'moderator';
+export type User = {
+  id: string;
+  email: string | null;
+  displayName: string;
+  role: UserRole;
+  createdAt: string;
+  deletedAt: string | null;
+};
+
+export const DEV_SQLITE_USERS: ReadonlyArray<
+  Pick<User, 'id' | 'displayName' | 'role'>
+> = [
+  { id: 'sqlite-user', displayName: 'SQLite User', role: 'user' },
+  {
+    id: 'sqlite-moderator',
+    displayName: 'SQLite Moderator',
+    role: 'moderator',
+  },
+];


### PR DESCRIPTION
## Summary
- add a SQLite schema helper that creates the user table, photo.ownerid column, supporting indexes/trigger, and dev user seeds
- wire the helper into the sqlite adapter, add minimal user types, and document the local-first users & roles plan

## Testing
- pnpm lint
- pnpm typecheck

------
https://chatgpt.com/codex/tasks/task_e_68c9a5818e48832d86d2f0fd99383629